### PR TITLE
[INT-3374] Fixing FINDING_IS_VULNERABILITY constant

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,0 @@
-{
-  "hooks": {
-    "pre-commit": "lint-staged",
-    "pre-push": "yarn build"
-  }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `FINDING_IS_VULNERABILITY` constant. `sourceType` is now
+  `cisco_amp_finding` and `targetType` is now `cve`.
+
 ## 1.0.0 - 2022-04-11
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -107,7 +107,7 @@ The following relationships are created:
 | --------------------- | --------------------- | --------------------- |
 | `cisco_amp_account`   | **HAS**               | `cisco_amp_endpoint`  |
 | `cisco_amp_endpoint`  | **IDENTIFIED**        | `cisco_amp_finding`   |
-| `cisco_amp_endpoint`  | **IS**                | `cisco_amp_account`   |
+| `cisco_amp_finding`   | **IS**                | `cve`                 |
 
 ### Mapped Relationships
 

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -113,9 +113,9 @@ export const Relationships: Record<
   },
   FINDING_IS_VULNERABILITY: {
     _type: 'cisco_amp_finding_is_cve',
-    sourceType: Entities.COMPUTER._type,
+    sourceType: Entities.FINDING._type,
     _class: RelationshipClass.IS,
-    targetType: Entities.ACCOUNT._type,
+    targetType: Entities.VULNERABILITY._type,
   },
 };
 


### PR DESCRIPTION
# Description

This PR fixes an issue where the `FINDING_IS_VULNERABILITY` constant was using the wrong `sourceType` and `targetType`.

Curiously, I wasn't getting warnings about undeclared types or failing `toMatchStepMetadata`. This is something to look into further.
